### PR TITLE
Parse numeric IDs before Prisma operations

### DIFF
--- a/backend/routes/equipos.ts
+++ b/backend/routes/equipos.ts
@@ -68,6 +68,7 @@ router.put("/:id", async (req: Request, res: Response): Promise<void> => {
 
   const { id } = req.params;
   const { name, type, location, acquiredAt, status, groupId } = typedReq.body;
+  const userId = Number(id);
 
   if (!name || !type || !location || !status) {
     res.status(400).json({ message: "Faltan campos obligatorios" });
@@ -76,7 +77,7 @@ router.put("/:id", async (req: Request, res: Response): Promise<void> => {
 
   try {
     const actualizado = await prisma.equipment.update({
-      where: { id },
+      where: { id: userId },
       data: {
         name,
         type,
@@ -101,9 +102,11 @@ router.delete("/:id", async (req: Request, res: Response): Promise<void> => {
     res.status(401).json({ message: "No autorizado" });
     return;
   }
+  const { id } = req.params;
+  const userId = Number(id);
 
   try {
-    await prisma.equipment.delete({ where: { id: req.params.id } });
+    await prisma.equipment.delete({ where: { id: userId } });
     res.status(204).send(); // ✅ Correcto
   } catch (err) {
     console.error("Error al eliminar equipo:", err);

--- a/backend/routes/grupos.ts
+++ b/backend/routes/grupos.ts
@@ -54,10 +54,11 @@ router.post("/", async (req: AuthenticatedRequest, res: Response): Promise<void>
 // ✅ DELETE: Eliminar grupo (solo si no tiene equipos asociados)
 router.delete("/:id", async (req: AuthenticatedRequest, res: Response): Promise<void> => {
   const { id } = req.params;
+  const userId = Number(id);
 
   try {
     // Verificar que el grupo exista
-    const grupo = await prisma.equipmentGroup.findUnique({ where: { id } });
+    const grupo = await prisma.equipmentGroup.findUnique({ where: { id: userId } });
 
     if (!grupo) {
       res.status(404).json({ message: "Grupo no encontrado" });
@@ -66,7 +67,7 @@ router.delete("/:id", async (req: AuthenticatedRequest, res: Response): Promise<
 
     // Verificar si tiene equipos asociados
     const equipos = await prisma.equipment.findMany({
-      where: { groupId: id },
+      where: { groupId: userId },
     });
 
     if (equipos.length > 0) {
@@ -76,7 +77,7 @@ router.delete("/:id", async (req: AuthenticatedRequest, res: Response): Promise<
       return;
     }
 
-    await prisma.equipmentGroup.delete({ where: { id } });
+    await prisma.equipmentGroup.delete({ where: { id: userId } });
     res.status(204).send();
   } catch (error) {
     console.error("Error al eliminar grupo:", error);


### PR DESCRIPTION
## Summary
- parse `id` params to numbers before Prisma updates and deletes
- ensure equipment and group routes use numeric IDs in `where` clauses

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689d113ec0208323869fa5b0a7b1263a