### PR TITLE
Handle Prisma P2025 errors on update and delete routes

### DIFF
--- a/backend/routes/equipos.ts
+++ b/backend/routes/equipos.ts
@@ -1,5 +1,5 @@
 import express, { Request, Response } from "express";
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient, Prisma } from "@prisma/client";
 import { AuthenticatedRequest } from "../middleware/authenticateJWT.js";
 
 const router = express.Router();
@@ -89,6 +89,10 @@ router.put("/:id", async (req: Request, res: Response): Promise<void> => {
 
     res.json(actualizado);
   } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2025") {
+      res.status(404).json({ message: "Usuario no encontrado" });
+      return;
+    }
     console.error("Error al actualizar equipo:", err);
     res.status(500).json({ message: "Error interno al actualizar equipo" });
   }
@@ -106,6 +110,10 @@ router.delete("/:id", async (req: Request, res: Response): Promise<void> => {
     await prisma.equipment.delete({ where: { id: req.params.id } });
     res.status(204).send(); // ✅ Correcto
   } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2025") {
+      res.status(404).json({ message: "Usuario no encontrado" });
+      return;
+    }
     console.error("Error al eliminar equipo:", err);
     res.status(500).json({ message: "Error interno al eliminar equipo" });
   }

--- a/backend/routes/grupos.ts
+++ b/backend/routes/grupos.ts
@@ -1,5 +1,5 @@
 import express, { Response } from "express";
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient, Prisma } from "@prisma/client";
 import { AuthenticatedRequest } from "../middleware/authenticateJWT";
 
 const router = express.Router();
@@ -79,6 +79,10 @@ router.delete("/:id", async (req: AuthenticatedRequest, res: Response): Promise<
     await prisma.equipmentGroup.delete({ where: { id } });
     res.status(204).send();
   } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2025") {
+      res.status(404).json({ message: "Usuario no encontrado" });
+      return;
+    }
     console.error("Error al eliminar grupo:", error);
     res.status(500).json({ message: "Error al eliminar grupo" });
   }

--- a/backend/routes/maintenances.ts
+++ b/backend/routes/maintenances.ts
@@ -1,5 +1,5 @@
 import express, { Request, Response } from "express";
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient, Prisma } from "@prisma/client";
 import authenticateJWT, { AuthenticatedRequest } from "../middleware/authenticateJWT.js";
 
 const router = express.Router();
@@ -17,6 +17,10 @@ router.delete(
       await prisma.file.delete({ where: { id: req.params.archivoId } });
       res.status(200).json({ message: "Archivo eliminado" });
     } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2025") {
+        res.status(404).json({ message: "Usuario no encontrado" });
+        return;
+      }
       console.error("Error al eliminar archivo:", error);
       res.status(500).json({ message: "Error al eliminar archivo" });
     }
@@ -160,6 +164,10 @@ router.put(
 
       res.status(200).json(actualizado);
     } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2025") {
+        res.status(404).json({ message: "Usuario no encontrado" });
+        return;
+      }
       console.error("Error al actualizar mantenimiento:", error);
       res.status(500).json({ message: "Error interno" });
     }
@@ -178,6 +186,10 @@ router.delete(
       await prisma.maintenance.delete({ where: { id: req.params.id } });
       res.status(204).end();
     } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2025") {
+        res.status(404).json({ message: "Usuario no encontrado" });
+        return;
+      }
       console.error("Error al eliminar mantenimiento:", error);
       res.status(500).json({ message: "Error interno" });
     }


### PR DESCRIPTION
## Summary
- catch Prisma P2025 errors on PUT and DELETE routes for equipment, groups, and maintenances
- return 404 with `Usuario no encontrado` when record is missing

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689d11322f788323837aa757884aa603