### PR TITLE
feat: user management panel

### DIFF
--- a/backend/routes/users.ts
+++ b/backend/routes/users.ts
@@ -1,0 +1,69 @@
+import express, { Response } from "express";
+import { PrismaClient } from "@prisma/client";
+import authenticateJWT, { AuthenticatedRequest } from "../middleware/authenticateJWT.js";
+
+const router = express.Router();
+const prisma = new PrismaClient();
+
+// GET: Obtener todos los usuarios (solo admin)
+router.get("/", authenticateJWT, async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+  if (req.user?.role !== "ADMIN") {
+    res.status(403).json({ message: "No autorizado" });
+    return;
+  }
+
+  try {
+    const users = await prisma.user.findMany({
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        role: true,
+        createdAt: true,
+      },
+    });
+    res.json(users);
+  } catch (_error) {
+    res.status(500).json({ error: "Error al obtener usuarios" });
+  }
+});
+
+// PUT: Actualizar un usuario
+router.put("/:id", authenticateJWT, async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+  const { id } = req.params;
+  const { name, email, role } = req.body;
+
+  if (req.user?.role !== "ADMIN") {
+    res.status(403).json({ message: "No autorizado" });
+    return;
+  }
+
+  try {
+    const updatedUser = await prisma.user.update({
+      where: { id },
+      data: { name, email, role },
+    });
+    res.json(updatedUser);
+  } catch (_error) {
+    res.status(500).json({ error: "Error al actualizar usuario" });
+  }
+});
+
+// DELETE: Eliminar un usuario
+router.delete("/:id", authenticateJWT, async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+  const { id } = req.params;
+
+  if (req.user?.role !== "ADMIN") {
+    res.status(403).json({ message: "No autorizado" });
+    return;
+  }
+
+  try {
+    await prisma.user.delete({ where: { id } });
+    res.json({ message: "Usuario eliminado correctamente" });
+  } catch (_error) {
+    res.status(500).json({ error: "Error al eliminar usuario" });
+  }
+});
+
+export default router;

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -8,6 +8,7 @@ import equiposRoutes from "./routes/equipos.js";
 import mantenimientosRoutes from "./routes/maintenances.js";
 import gruposRoutes from "./routes/grupos.js";
 import statsRoutes from "./routes/stats.js";
+import usersRoutes from "./routes/users.js";
 import authenticateJWT from "./middleware/authenticateJWT.js";
 // import authProtegidoRoutes from "./routes/authProtegido.js";
 
@@ -48,6 +49,7 @@ app.use("/api/equipos", equiposRoutes);
 app.use("/api/mantenimientos", mantenimientosRoutes);
 app.use("/api/grupos", authenticateJWT, gruposRoutes);
 app.use("/api/stats", statsRoutes);
+app.use("/api/users", usersRoutes);
 
 // Puerto
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- add admin routes to list, update and delete users
- expose user management tab in dashboard settings for admins

## Testing
- `npm test` (backend)
- `npm test` (frontend; missing script)
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689d0ce2b8088323886434da58f66f91